### PR TITLE
Rundall/svcplan 8272/no profile files for sles 15 sp6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,8 +165,10 @@ class profile_motd (
     require => File['/etc/motd.d'],
   }
 
-  if ( ($facts['os']['release']['major'] < '8' and $facts['os']['family'] == 'RedHat' ) or $facts['os']['family'] == 'Suse') {
-    ## ADD /etc/motd.d/* SUPPORT TO RHEL7, SUSE, ETC
+  if ( ($facts['os']['release']['major'] < '8' and $facts['os']['family'] == 'RedHat' ) or
+       ($facts['os']['family'] == 'Suse' and $facts['os']['release']['major'] == '15' and $facts['os']['release']['minor'] < '6' ) or
+       ($facts['os']['family'] == 'Suse' and $facts['os']['release']['major'] < '15') ) {
+    ## ADD /etc/motd.d/* SUPPORT TO RHEL7, SUSE 15 SP5 and older, ETC
     File {
       mode   => '0644',
     }


### PR DESCRIPTION
SVCPLAN-8272: no profile.d/motd files for SLES 15 SP6
    
    SLES 15 SP6 adds 'session optional pam_motd.so' to /etc/pam.d/sshd
    so we no longer need the motd scripts in /etc/profile.d/.
